### PR TITLE
Enable travis ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-  - 2.2.0
+  - 2.2.2

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/codebreakdown/togl.svg?branch=master)](https://travis-ci.org/codebreakdown/togl)
+
 # Togl
 
 A lightweight feature toggle library.

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,6 @@
 require "bundler/gem_tasks"
+require 'rspec/core/rake_task'
 
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec


### PR DESCRIPTION
Enabled Travis-CI builds so that we could make sure that the test suite stays as awesome as it is right now.